### PR TITLE
Add scale and rotate tween features

### DIFF
--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourRotate.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourRotate.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace UniAwaitableTween.Runtime
+{
+    /// <summary>
+    /// 回転シーケンス.
+    /// </summary>
+    public sealed class BehaviourRotate : BehaviourBase<Quaternion>
+    {
+        private readonly Transform _origin;
+
+        public BehaviourRotate(Transform origin, Quaternion end, float duration)
+            : base(origin.rotation, end, Time.time, Time.time + duration)
+        {
+            _origin = origin;
+        }
+
+        protected override void UpdateLerp(Quaternion start, Quaternion end, float t)
+        {
+            _origin.rotation = Quaternion.Lerp(start, end, t);
+        }
+    }
+}

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourRotate.cs.meta
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourRotate.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f9b7dd5d-3dcb-4c3b-b381-5251afdc5866
+timeCreated: 1749058398

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourScale.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourScale.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace UniAwaitableTween.Runtime
+{
+    /// <summary>
+    /// 拡縮シーケンス.
+    /// </summary>
+    public sealed class BehaviourScale : BehaviourBase<Vector3>
+    {
+        private readonly Transform _origin;
+
+        public BehaviourScale(Transform origin, Vector3 end, float duration)
+            : base(origin.localScale, end, Time.time, Time.time + duration)
+        {
+            _origin = origin;
+        }
+
+        protected override void UpdateLerp(Vector3 start, Vector3 end, float t)
+        {
+            _origin.localScale = Vector3.Lerp(start, end, t);
+        }
+    }
+}

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourScale.cs.meta
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourScale.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 73baa59f-dbd5-47de-bb41-64147a730e56
+timeCreated: 1749058398

--- a/Assets/UniAwaitableTween/Runtime/Tween.cs
+++ b/Assets/UniAwaitableTween/Runtime/Tween.cs
@@ -20,6 +20,22 @@ namespace UniAwaitableTween.Runtime
         {
             await BehaviourController.PlayAsync(new BehaviourMove(origin, end, duration), ct);
         }
+
+        /// <summary>
+        /// Transform.Scale
+        /// </summary>
+        public static async UniTask Scale(Transform origin, Vector3 end, float duration, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new BehaviourScale(origin, end, duration), ct);
+        }
+
+        /// <summary>
+        /// Transform.Rotation
+        /// </summary>
+        public static async UniTask Rotate(Transform origin, Quaternion end, float duration, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new BehaviourRotate(origin, end, duration), ct);
+        }
         
         /// <summary>
         /// カラーフェード.
@@ -50,6 +66,24 @@ namespace UniAwaitableTween.Runtime
         public static async UniTask<Transform> Move(this Transform origin, Vector3 target, float duration, CancellationToken ct = default)
         {
             await BehaviourController.PlayAsync(new BehaviourMove(origin, target, duration), ct);
+            return origin;
+        }
+
+        /// <summary>
+        /// Transform.Scale
+        /// </summary>
+        public static async UniTask<Transform> Scale(this Transform origin, Vector3 target, float duration, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new BehaviourScale(origin, target, duration), ct);
+            return origin;
+        }
+
+        /// <summary>
+        /// Transform.Rotate
+        /// </summary>
+        public static async UniTask<Transform> Rotate(this Transform origin, Quaternion target, float duration, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new BehaviourRotate(origin, target, duration), ct);
             return origin;
         }
     }

--- a/Assets/UniAwaitableTween/Sample/Sample.cs
+++ b/Assets/UniAwaitableTween/Sample/Sample.cs
@@ -14,6 +14,10 @@ public class Sample : MonoBehaviour
         await Tween.Move(_target, Vector3.down, 0.1f);
         await _target.Move(Vector3.left, 0.1f);
         await _target.Move(Vector3.right, 0.1f);
+        await Tween.Scale(_target, Vector3.one * 2f, 0.1f);
+        await Tween.Scale(_target, Vector3.one, 0.1f);
+        await Tween.Rotate(_target, Quaternion.Euler(0f, 90f, 0f), 0.1f);
+        await Tween.Rotate(_target, Quaternion.identity, 0.1f);
         await Tween.ColorFade(_target.gameObject.GetComponent<MeshRenderer>().material, Color.black, 1f);
         await Tween.ColorFade(_target.gameObject.GetComponent<MeshRenderer>().material, Color.white, 1f);
     }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # UniAwaitableTween
+
+An awaitable Tween library for Unity using [UniTask](https://github.com/Cysharp/UniTask).
+
+## Features
+
+- Move, Scale and Rotate transforms asynchronously
+- Fade material colors
+- Cancellation support via `CancellationToken`


### PR DESCRIPTION
## Summary
- add `BehaviourScale` and `BehaviourRotate` for scaling and rotating
- expose `Scale` and `Rotate` methods in `Tween` and extension methods
- demonstrate new features in sample scene
- document features in README

## Testing
- `msbuild /version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684082f3719c8324ac297957b17fd0ed