### PR TITLE
Rename Move parameter

### DIFF
--- a/Assets/UniAwaitableTween/Runtime/Tween.cs
+++ b/Assets/UniAwaitableTween/Runtime/Tween.cs
@@ -13,12 +13,12 @@ namespace UniAwaitableTween.Runtime
         /// Transform.Position
         /// </summary>
         /// <param name="origin"></param>
-        /// <param name="end"></param>
+        /// <param name="offset">移動させる距離.</param>
         /// <param name="duration"></param>
         /// <param name="ct"></param>
-        public static async UniTask Move(Transform origin, Vector3 end, float duration, CancellationToken ct = default)
+        public static async UniTask Move(Transform origin, Vector3 offset, float duration, CancellationToken ct = default)
         {
-            await BehaviourController.PlayAsync(new BehaviourMove(origin, end, duration), ct);
+            await BehaviourController.PlayAsync(new BehaviourMove(origin, offset, duration), ct);
         }
         
         /// <summary>
@@ -43,13 +43,13 @@ namespace UniAwaitableTween.Runtime
         /// Transform.Position
         /// </summary>
         /// <param name="origin"></param>
-        /// <param name="target"></param>
+        /// <param name="offset"></param>
         /// <param name="duration"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        public static async UniTask<Transform> Move(this Transform origin, Vector3 target, float duration, CancellationToken ct = default)
+        public static async UniTask<Transform> Move(this Transform origin, Vector3 offset, float duration, CancellationToken ct = default)
         {
-            await BehaviourController.PlayAsync(new BehaviourMove(origin, target, duration), ct);
+            await BehaviourController.PlayAsync(new BehaviourMove(origin, offset, duration), ct);
             return origin;
         }
     }


### PR DESCRIPTION
## Summary
- rename `end` parameter in `Tween.Move` to `offset`
- update docs and extension method accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684083a2523083249e39131890c43dd4