### PR TITLE
Ensure tween reaches final value

### DIFF
--- a/Assets/UniAwaitableTween/Runtime/Internal/BehaviourBase.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/BehaviourBase.cs
@@ -36,6 +36,8 @@ namespace UniAwaitableTween.Runtime
 
                 if (t >= 1f)
                 {
+                    // force final value so the last frame always reaches the end
+                    SetLerpT(1f);
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- force the final frame of a tween to reach its end value

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684083a747508324b57804962f9bfbcf