### PR TITLE
Add local transform tween methods

### DIFF
--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourMoveLocal.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourMoveLocal.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace UniAwaitableTween.Runtime
+{
+    /// <summary>
+    /// ローカル移動シーケンス.
+    /// </summary>
+    public sealed class BehaviourMoveLocal : BehaviourBase<Vector3>
+    {
+        private readonly Transform _origin;
+
+        public BehaviourMoveLocal(Transform origin, Vector3 value, float duration)
+            : base(origin.localPosition, origin.localPosition + value, Time.time, Time.time + duration)
+        {
+            _origin = origin;
+        }
+
+        protected override void UpdateLerp(Vector3 start, Vector3 end, float t)
+        {
+            _origin.localPosition = Vector3.Lerp(start, end, t);
+        }
+    }
+}

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourMoveLocal.cs.meta
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourMoveLocal.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6110277a-b151-4ee9-b682-fa7ecc44bb67
+timeCreated: 1749059374

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourRotateLocal.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourRotateLocal.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace UniAwaitableTween.Runtime
+{
+    /// <summary>
+    /// ローカル回転シーケンス.
+    /// </summary>
+    public sealed class BehaviourRotateLocal : BehaviourBase<Quaternion>
+    {
+        private readonly Transform _origin;
+
+        public BehaviourRotateLocal(Transform origin, Quaternion end, float duration)
+            : base(origin.localRotation, end, Time.time, Time.time + duration)
+        {
+            _origin = origin;
+        }
+
+        protected override void UpdateLerp(Quaternion start, Quaternion end, float t)
+        {
+            _origin.localRotation = Quaternion.Lerp(start, end, t);
+        }
+    }
+}

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourRotateLocal.cs.meta
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourRotateLocal.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cadc1171-df08-4b01-87f9-2a161397eef3
+timeCreated: 1749059374

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourScaleLocal.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourScaleLocal.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace UniAwaitableTween.Runtime
+{
+    /// <summary>
+    /// ローカル拡縮シーケンス.
+    /// </summary>
+    public sealed class BehaviourScaleLocal : BehaviourBase<Vector3>
+    {
+        private readonly Transform _origin;
+
+        public BehaviourScaleLocal(Transform origin, Vector3 end, float duration)
+            : base(origin.localScale, end, Time.time, Time.time + duration)
+        {
+            _origin = origin;
+        }
+
+        protected override void UpdateLerp(Vector3 start, Vector3 end, float t)
+        {
+            _origin.localScale = Vector3.Lerp(start, end, t);
+        }
+    }
+}

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourScaleLocal.cs.meta
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourScaleLocal.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 09c07c5c-6c74-4b15-95e2-592e4a89036b
+timeCreated: 1749059374

--- a/Assets/UniAwaitableTween/Runtime/Tween.cs
+++ b/Assets/UniAwaitableTween/Runtime/Tween.cs
@@ -22,6 +22,14 @@ namespace UniAwaitableTween.Runtime
         }
 
         /// <summary>
+        /// Transform.LocalPosition
+        /// </summary>
+        public static async UniTask MoveLocal(Transform origin, Vector3 offset, float duration, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new BehaviourMoveLocal(origin, offset, duration), ct);
+        }
+
+        /// <summary>
         /// Transform.Scale
         /// </summary>
         public static async UniTask Scale(Transform origin, Vector3 end, float duration, CancellationToken ct = default)
@@ -30,11 +38,27 @@ namespace UniAwaitableTween.Runtime
         }
 
         /// <summary>
+        /// Transform.LocalScale
+        /// </summary>
+        public static async UniTask ScaleLocal(Transform origin, Vector3 end, float duration, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new BehaviourScaleLocal(origin, end, duration), ct);
+        }
+
+        /// <summary>
         /// Transform.Rotation
         /// </summary>
         public static async UniTask Rotate(Transform origin, Quaternion end, float duration, CancellationToken ct = default)
         {
             await BehaviourController.PlayAsync(new BehaviourRotate(origin, end, duration), ct);
+        }
+
+        /// <summary>
+        /// Transform.LocalRotation
+        /// </summary>
+        public static async UniTask RotateLocal(Transform origin, Quaternion end, float duration, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new BehaviourRotateLocal(origin, end, duration), ct);
         }
         
         /// <summary>
@@ -70,6 +94,15 @@ namespace UniAwaitableTween.Runtime
         }
 
         /// <summary>
+        /// Transform.LocalPosition
+        /// </summary>
+        public static async UniTask<Transform> MoveLocal(this Transform origin, Vector3 offset, float duration, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new BehaviourMoveLocal(origin, offset, duration), ct);
+            return origin;
+        }
+
+        /// <summary>
         /// Transform.Scale
         /// </summary>
         public static async UniTask<Transform> Scale(this Transform origin, Vector3 target, float duration, CancellationToken ct = default)
@@ -79,11 +112,29 @@ namespace UniAwaitableTween.Runtime
         }
 
         /// <summary>
+        /// Transform.LocalScale
+        /// </summary>
+        public static async UniTask<Transform> ScaleLocal(this Transform origin, Vector3 target, float duration, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new BehaviourScaleLocal(origin, target, duration), ct);
+            return origin;
+        }
+
+        /// <summary>
         /// Transform.Rotate
         /// </summary>
         public static async UniTask<Transform> Rotate(this Transform origin, Quaternion target, float duration, CancellationToken ct = default)
         {
             await BehaviourController.PlayAsync(new BehaviourRotate(origin, target, duration), ct);
+            return origin;
+        }
+
+        /// <summary>
+        /// Transform.LocalRotation
+        /// </summary>
+        public static async UniTask<Transform> RotateLocal(this Transform origin, Quaternion target, float duration, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new BehaviourRotateLocal(origin, target, duration), ct);
             return origin;
         }
     }

--- a/Assets/UniAwaitableTween/Sample/Sample.cs
+++ b/Assets/UniAwaitableTween/Sample/Sample.cs
@@ -14,10 +14,18 @@ public class Sample : MonoBehaviour
         await Tween.Move(_target, Vector3.down, 0.1f);
         await _target.Move(Vector3.left, 0.1f);
         await _target.Move(Vector3.right, 0.1f);
+        await Tween.MoveLocal(_target, Vector3.forward, 0.1f);
+        await Tween.MoveLocal(_target, Vector3.back, 0.1f);
+        await _target.MoveLocal(Vector3.left, 0.1f);
+        await _target.MoveLocal(Vector3.right, 0.1f);
         await Tween.Scale(_target, Vector3.one * 2f, 0.1f);
         await Tween.Scale(_target, Vector3.one, 0.1f);
+        await Tween.ScaleLocal(_target, Vector3.one * 0.5f, 0.1f);
+        await Tween.ScaleLocal(_target, Vector3.one, 0.1f);
         await Tween.Rotate(_target, Quaternion.Euler(0f, 90f, 0f), 0.1f);
         await Tween.Rotate(_target, Quaternion.identity, 0.1f);
+        await Tween.RotateLocal(_target, Quaternion.Euler(0f, 0f, 90f), 0.1f);
+        await Tween.RotateLocal(_target, Quaternion.identity, 0.1f);
         await Tween.ColorFade(_target.gameObject.GetComponent<MeshRenderer>().material, Color.black, 1f);
         await Tween.ColorFade(_target.gameObject.GetComponent<MeshRenderer>().material, Color.white, 1f);
     }
@@ -31,6 +39,8 @@ public class Sample : MonoBehaviour
             _cts = new CancellationTokenSource();
             await Tween.Move(_target, Vector3.up, 0.1f, _cts.Token);
             await Tween.Move(_target, Vector3.down, 0.1f, _cts.Token);
+            await Tween.MoveLocal(_target, Vector3.forward, 0.1f, _cts.Token);
+            await Tween.MoveLocal(_target, Vector3.back, 0.1f, _cts.Token);
         }
     }
 


### PR DESCRIPTION
## Summary
- add methods `MoveLocal`, `RotateLocal`, and `ScaleLocal`
- create behaviour classes to tween local transform properties
- expose extension methods for local tweens
- update sample scene script to demonstrate new tweens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684086d8d93c83248721eddcd71a712f