### PR TITLE
Add easing support

### DIFF
--- a/Assets/UniAwaitableTween/Runtime/Easing.cs
+++ b/Assets/UniAwaitableTween/Runtime/Easing.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+namespace UniAwaitableTween.Runtime
+{
+    public enum EasingType
+    {
+        Linear,
+        EaseInOut,
+        EaseOutQuad,
+    }
+
+    public static class Easing
+    {
+        public static float Evaluate(EasingType type, float t)
+        {
+            switch (type)
+            {
+                case EasingType.EaseInOut:
+                    return EaseInOut(t);
+                case EasingType.EaseOutQuad:
+                    return EaseOutQuad(t);
+                case EasingType.Linear:
+                default:
+                    return t;
+            }
+        }
+
+        public static float EaseInOut(float t)
+        {
+            return t * t * (3f - 2f * t);
+        }
+
+        public static float EaseOutQuad(float t)
+        {
+            return t * (2f - t);
+        }
+    }
+}

--- a/Assets/UniAwaitableTween/Runtime/Internal/BehaviourBase.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/BehaviourBase.cs
@@ -7,6 +7,7 @@ namespace UniAwaitableTween.Runtime
     public abstract class BehaviourBase<TValue> : IBehaviour
     {
         private readonly BehaviourData<TValue> _data;
+        private readonly EasingType _easing;
 
         /// <summary>
         /// 補間データの初期化.
@@ -15,9 +16,10 @@ namespace UniAwaitableTween.Runtime
         /// <param name="end"></param>
         /// <param name="startTime"></param>
         /// <param name="endTime"></param>
-        protected BehaviourBase(TValue begin, TValue end, float startTime, float endTime)
+        protected BehaviourBase(TValue begin, TValue end, float startTime, float endTime, EasingType easing = EasingType.Linear)
         {
             _data = new BehaviourData<TValue>(begin, end, startTime, endTime);
+            _easing = easing;
         }
         
         /// <summary>
@@ -32,6 +34,7 @@ namespace UniAwaitableTween.Runtime
 
                 var t = (Time.time - _data.StartTime) / (_data.EndTime - _data.StartTime);
                 t = Mathf.Clamp01(t);
+                t = Easing.Evaluate(_easing, t);
                 UpdateLerp(_data.Start, _data.End, t);
 
                 if (t >= 1f)
@@ -51,7 +54,7 @@ namespace UniAwaitableTween.Runtime
         /// <param name="t"></param>
         public void SetLerpT(float t)
         {
-            UpdateLerp(_data.Start, _data.End, t);
+            UpdateLerp(_data.Start, _data.End, Easing.Evaluate(_easing, t));
         }
 
         /// <summary>

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourColor.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourColor.cs
@@ -6,8 +6,8 @@ namespace UniAwaitableTween.Runtime
     {
         private readonly Material _origin;
         
-        public BehaviourColor(Material origin, Color value, float duration)
-            : base(origin.color, value, Time.time, Time.time + duration)
+        public BehaviourColor(Material origin, Color value, float duration, EasingType easing = EasingType.Linear)
+            : base(origin.color, value, Time.time, Time.time + duration, easing)
         {
             _origin = origin;
         }

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourMove.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourMove.cs
@@ -9,8 +9,8 @@ namespace UniAwaitableTween.Runtime
     {
         private readonly Transform _origin;
 
-        public BehaviourMove(Transform origin, Vector3 value, float duration)
-            : base(origin.position, origin.position + value, Time.time, Time.time + duration)
+        public BehaviourMove(Transform origin, Vector3 value, float duration, EasingType easing = EasingType.Linear)
+            : base(origin.position, origin.position + value, Time.time, Time.time + duration, easing)
         {
             _origin = origin;
         }

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourRotate.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourRotate.cs
@@ -9,8 +9,8 @@ namespace UniAwaitableTween.Runtime
     {
         private readonly Transform _origin;
 
-        public BehaviourRotate(Transform origin, Quaternion end, float duration)
-            : base(origin.rotation, end, Time.time, Time.time + duration)
+        public BehaviourRotate(Transform origin, Quaternion end, float duration, EasingType easing = EasingType.Linear)
+            : base(origin.rotation, end, Time.time, Time.time + duration, easing)
         {
             _origin = origin;
         }

--- a/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourScale.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/Behaviours/BehaviourScale.cs
@@ -9,8 +9,8 @@ namespace UniAwaitableTween.Runtime
     {
         private readonly Transform _origin;
 
-        public BehaviourScale(Transform origin, Vector3 end, float duration)
-            : base(origin.localScale, end, Time.time, Time.time + duration)
+        public BehaviourScale(Transform origin, Vector3 end, float duration, EasingType easing = EasingType.Linear)
+            : base(origin.localScale, end, Time.time, Time.time + duration, easing)
         {
             _origin = origin;
         }

--- a/Assets/UniAwaitableTween/Runtime/Tween.cs
+++ b/Assets/UniAwaitableTween/Runtime/Tween.cs
@@ -16,25 +16,25 @@ namespace UniAwaitableTween.Runtime
         /// <param name="offset">移動させる距離.</param>
         /// <param name="duration"></param>
         /// <param name="ct"></param>
-        public static async UniTask Move(Transform origin, Vector3 offset, float duration, CancellationToken ct = default)
+        public static async UniTask Move(Transform origin, Vector3 offset, float duration, EasingType easing = EasingType.Linear, CancellationToken ct = default)
         {
-            await BehaviourController.PlayAsync(new BehaviourMove(origin, offset, duration), ct);
+            await BehaviourController.PlayAsync(new BehaviourMove(origin, offset, duration, easing), ct);
         }
 
         /// <summary>
         /// Transform.Scale
         /// </summary>
-        public static async UniTask Scale(Transform origin, Vector3 end, float duration, CancellationToken ct = default)
+        public static async UniTask Scale(Transform origin, Vector3 end, float duration, EasingType easing = EasingType.Linear, CancellationToken ct = default)
         {
-            await BehaviourController.PlayAsync(new BehaviourScale(origin, end, duration), ct);
+            await BehaviourController.PlayAsync(new BehaviourScale(origin, end, duration, easing), ct);
         }
 
         /// <summary>
         /// Transform.Rotation
         /// </summary>
-        public static async UniTask Rotate(Transform origin, Quaternion end, float duration, CancellationToken ct = default)
+        public static async UniTask Rotate(Transform origin, Quaternion end, float duration, EasingType easing = EasingType.Linear, CancellationToken ct = default)
         {
-            await BehaviourController.PlayAsync(new BehaviourRotate(origin, end, duration), ct);
+            await BehaviourController.PlayAsync(new BehaviourRotate(origin, end, duration, easing), ct);
         }
         
         /// <summary>
@@ -44,9 +44,9 @@ namespace UniAwaitableTween.Runtime
         /// <param name="end"></param>
         /// <param name="duration"></param>
         /// <param name="ct"></param>
-        public static async UniTask ColorFade(Material origin, Color end, float duration, CancellationToken ct = default)
+        public static async UniTask ColorFade(Material origin, Color end, float duration, EasingType easing = EasingType.Linear, CancellationToken ct = default)
         {
-            await BehaviourController.PlayAsync(new BehaviourColor(origin, end, duration), ct);
+            await BehaviourController.PlayAsync(new BehaviourColor(origin, end, duration, easing), ct);
         }
     }
 
@@ -63,27 +63,27 @@ namespace UniAwaitableTween.Runtime
         /// <param name="duration"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        public static async UniTask<Transform> Move(this Transform origin, Vector3 offset, float duration, CancellationToken ct = default)
+        public static async UniTask<Transform> Move(this Transform origin, Vector3 offset, float duration, EasingType easing = EasingType.Linear, CancellationToken ct = default)
         {
-            await BehaviourController.PlayAsync(new BehaviourMove(origin, offset, duration), ct);
+            await BehaviourController.PlayAsync(new BehaviourMove(origin, offset, duration, easing), ct);
             return origin;
         }
 
         /// <summary>
         /// Transform.Scale
         /// </summary>
-        public static async UniTask<Transform> Scale(this Transform origin, Vector3 target, float duration, CancellationToken ct = default)
+        public static async UniTask<Transform> Scale(this Transform origin, Vector3 target, float duration, EasingType easing = EasingType.Linear, CancellationToken ct = default)
         {
-            await BehaviourController.PlayAsync(new BehaviourScale(origin, target, duration), ct);
+            await BehaviourController.PlayAsync(new BehaviourScale(origin, target, duration, easing), ct);
             return origin;
         }
 
         /// <summary>
         /// Transform.Rotate
         /// </summary>
-        public static async UniTask<Transform> Rotate(this Transform origin, Quaternion target, float duration, CancellationToken ct = default)
+        public static async UniTask<Transform> Rotate(this Transform origin, Quaternion target, float duration, EasingType easing = EasingType.Linear, CancellationToken ct = default)
         {
-            await BehaviourController.PlayAsync(new BehaviourRotate(origin, target, duration), ct);
+            await BehaviourController.PlayAsync(new BehaviourRotate(origin, target, duration, easing), ct);
             return origin;
         }
     }

--- a/Assets/UniAwaitableTween/Sample/Sample.cs
+++ b/Assets/UniAwaitableTween/Sample/Sample.cs
@@ -10,11 +10,11 @@ public class Sample : MonoBehaviour
 
     private async void Start()
     {
-        await Tween.Move(_target, Vector3.up, 0.1f);
+        await Tween.Move(_target, Vector3.up, 0.1f, easing: EasingType.EaseOutQuad);
         await Tween.Move(_target, Vector3.down, 0.1f);
         await _target.Move(Vector3.left, 0.1f);
         await _target.Move(Vector3.right, 0.1f);
-        await Tween.Scale(_target, Vector3.one * 2f, 0.1f);
+        await Tween.Scale(_target, Vector3.one * 2f, 0.1f, easing: EasingType.EaseInOut);
         await Tween.Scale(_target, Vector3.one, 0.1f);
         await Tween.Rotate(_target, Quaternion.Euler(0f, 90f, 0f), 0.1f);
         await Tween.Rotate(_target, Quaternion.identity, 0.1f);
@@ -29,8 +29,8 @@ public class Sample : MonoBehaviour
             _cts?.Cancel();
             _cts?.Dispose();
             _cts = new CancellationTokenSource();
-            await Tween.Move(_target, Vector3.up, 0.1f, _cts.Token);
-            await Tween.Move(_target, Vector3.down, 0.1f, _cts.Token);
+            await Tween.Move(_target, Vector3.up, 0.1f, EasingType.EaseOutQuad, _cts.Token);
+            await Tween.Move(_target, Vector3.down, 0.1f, EasingType.EaseOutQuad, _cts.Token);
         }
     }
 


### PR DESCRIPTION
## Summary
- add `EasingType` enum and helper functions
- allow tweens to use easing
- update sample to demo ease

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684086da1f10832494b1dfc300ae9737