### PR TITLE
Add tween sequence and parallel classes

### DIFF
--- a/Assets/UniAwaitableTween/Runtime/Internal/TweenParallel.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/TweenParallel.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+
+namespace UniAwaitableTween.Runtime
+{
+    /// <summary>
+    /// Executes multiple <see cref="IBehaviour"/> instances concurrently.
+    /// </summary>
+    public sealed class TweenParallel : IBehaviour
+    {
+        private readonly IBehaviour[] _behaviours;
+
+        public TweenParallel(IEnumerable<IBehaviour> behaviours)
+        {
+            _behaviours = behaviours is IBehaviour[] array ? array : new List<IBehaviour>(behaviours).ToArray();
+        }
+
+        public async UniTask UpdateAsync(CancellationToken ct)
+        {
+            var tasks = new List<UniTask>(_behaviours.Count);
+            foreach (var behaviour in _behaviours)
+            {
+                tasks.Add(BehaviourController.PlayAsync(behaviour, ct));
+            }
+            await UniTask.WhenAll(tasks);
+        }
+
+        public void SetLerpT(float t)
+        {
+            foreach (var behaviour in _behaviours)
+            {
+                behaviour.SetLerpT(t);
+            }
+        }
+    }
+}

--- a/Assets/UniAwaitableTween/Runtime/Internal/TweenParallel.cs.meta
+++ b/Assets/UniAwaitableTween/Runtime/Internal/TweenParallel.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3f09b52b7ee74b77853c5d296ff2c9c7
+timeCreated: 1749059401

--- a/Assets/UniAwaitableTween/Runtime/Internal/TweenSequence.cs
+++ b/Assets/UniAwaitableTween/Runtime/Internal/TweenSequence.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+
+namespace UniAwaitableTween.Runtime
+{
+    /// <summary>
+    /// Executes multiple <see cref="IBehaviour"/> instances sequentially.
+    /// </summary>
+    public sealed class TweenSequence : IBehaviour
+    {
+        private readonly IBehaviour[] _behaviours;
+
+        public TweenSequence(IEnumerable<IBehaviour> behaviours)
+        {
+            _behaviours = behaviours is IBehaviour[] array ? array : new List<IBehaviour>(behaviours).ToArray();
+        }
+
+        public async UniTask UpdateAsync(CancellationToken ct)
+        {
+            foreach (var behaviour in _behaviours)
+            {
+                await BehaviourController.PlayAsync(behaviour, ct);
+            }
+        }
+
+        public void SetLerpT(float t)
+        {
+            foreach (var behaviour in _behaviours)
+            {
+                behaviour.SetLerpT(t);
+            }
+        }
+    }
+}

--- a/Assets/UniAwaitableTween/Runtime/Internal/TweenSequence.cs.meta
+++ b/Assets/UniAwaitableTween/Runtime/Internal/TweenSequence.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b759bc2a539d4f53a4e032950a0fd7b6
+timeCreated: 1749059401

--- a/Assets/UniAwaitableTween/Runtime/Tween.cs
+++ b/Assets/UniAwaitableTween/Runtime/Tween.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -47,6 +48,22 @@ namespace UniAwaitableTween.Runtime
         public static async UniTask ColorFade(Material origin, Color end, float duration, CancellationToken ct = default)
         {
             await BehaviourController.PlayAsync(new BehaviourColor(origin, end, duration), ct);
+        }
+
+        /// <summary>
+        /// Executes tweens sequentially.
+        /// </summary>
+        public static async UniTask Sequence(IEnumerable<IBehaviour> behaviours, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new TweenSequence(behaviours), ct);
+        }
+
+        /// <summary>
+        /// Executes tweens concurrently.
+        /// </summary>
+        public static async UniTask Parallel(IEnumerable<IBehaviour> behaviours, CancellationToken ct = default)
+        {
+            await BehaviourController.PlayAsync(new TweenParallel(behaviours), ct);
         }
     }
 


### PR DESCRIPTION
## Summary
- add TweenSequence & TweenParallel classes to hold multiple IBehaviour
- run behaviours sequentially or concurrently
- expose Tween.Sequence and Tween.Parallel API

## Testing
- `apt-get update`
- `apt-get install -y xxd`
- `apt-get install -y uuid-runtime`
- `apt-get install -y mono-mcs`
- *(compilation not run: Unity dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_684086ddf0c08324a30c7084cbbc1e42